### PR TITLE
Set default production HOST/PORT for Docker 

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -5,6 +5,11 @@ const zhTW = require('./i18n/zh-tw')
 module.exports = {
   mode: 'universal',
 
+  server: {
+    port: process.env.NODE_ENV === 'production' ? 80 : 8080,
+    host: process.env.NODE_ENV === 'production' ? '0.0.0.0' : '127.0.0.1'
+  },
+
   /*
   ** Headers of the page
   */


### PR DESCRIPTION
If node listen on `127.0.0.1` in Docker, it will only allow request from current host, which is the docker itself. The node server will be unreachable for requests out of the container.

In this pull request, I set the default Host to all address, `0.0.0.0`, and PORT to `80` for production.
This could enable the dockerization for further deployment, while other settings remain the same for development.