### PR TITLE
Fulfill developing cycle

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,9 +2,10 @@ workspace:
   base: /mirror-media
   path: mirror-voice
 pipeline:
-  stage_notify:
+  # Send build start message to slack when pull_request and push
+  build_start:
     image: plugins/slack
-    channel: jenkins
+    channel: ground_control
     secrets: [slack_webhook]
     username: drone
     icon_url: https://avatars2.githubusercontent.com/u/2181346?s=200&v=4
@@ -12,9 +13,23 @@ pipeline:
       Build <${DRONE_BUILD_LINK}|#{{build.number}}> *{{repo.name}}:${DRONE_COMMIT_SHA:0:7}* start.
       {{build.author}} gave *{{build.branch}}* a little {{build.event}}.
     when:
-      event: [push, pull_request, tag]
+      event:
+      - push
+      - pull_request
+
+  release_start:
+    image: plugins/slack
+    channel: ground_control
+    secrets: [slack_webhook]
+    username: drone
+    icon_url: https://avatars2.githubusercontent.com/u/2181346?s=200&v=4
+    template: >
+      Releasing mirror-voice:${DRONE_COMMIT_SHA:0.7}.
+    when:
+      event: [tag]
       branch: [master]
 
+  # Only need to restore cache if building is necessary, which is pull_request and push
   restore-cache:
     image: drillster/drone-volume-cache
     restore: true
@@ -23,19 +38,53 @@ pipeline:
     volumes:
       - /tmp/cache:/cache
     when:
-      event: [push, pull_request]
-      branch: [master]
+      event:
+        include:
+        - pull_request
+        - push
 
-  get-stage-config:
+  get-configs:
     image: gcr.io/mirrormedia-1470651750304/drone-cloud-sdk:latest
     secrets: [google_credentials]
     commands:
       - gcloud source repos clone configs ../configs
-      - cp ../configs/mirror-media/mirror-voice/dev/config.js ./server/config.js
     when:
-      event: [push]
+      event:
+      - push
+      - pull_request
+      - tag
+
+  configure-dev:
+    image: busybox:latest
+    commands:
+      - cp ../configs/mirror-media/mirror-voice/${DRONE_BRANCH}/config.js ./server/config.js
+    when:
+      event:
+        exclude:
+        - tag
+      branch:
+        exclude:
+        - master
+
+  configure-stage:
+    image: busybox:latest
+    commands:
+      - cp ../configs/mirror-media/mirror-voice/stage/config.js ./server/config.js
+    when:
+      event:
+      - push
+      branch:
+      - master
+
+  configure-prod:
+    image: busybox:latest
+    commands:
+      - cp ../configs/mirror-media/mirror-voice/prod/config.js ./server/config.js
+    when:
+      event: [tag]
       branch: [master]
 
+  # Build when pull_request are issued or commits pushed
   build:
     image: gcr.io/mirrormedia-1470651750304/mirror-voice:node-10.15.1-builder
     commands:
@@ -43,18 +92,37 @@ pipeline:
       - yarn run build
       - yarn cache clean
     when:
-      event: [push, tag]
+      event: [push, pull_request]
 
   publish:
     image: plugins/gcr
     repo: mirrormedia-1470651750304/${DRONE_REPO_NAME}
-    tag: ${DRONE_COMMIT_SHA:0:7}
+    tag:
+    - ${DRONE_BRANCH}
+    - ${DRONE_COMMIT_SHA:0:7}
     environment:
       - DOCKER_LAUNCH_DEBUG=true
     secrets: [google_credentials]
     dockerfile: docker/Dockerfile
+    # build_args: STAGE_VERSION=${DRONE_COMMIT_BEFORE:0:7}
+    target: stage
     when:
-      event: [push]
+      event:
+      - push
+      - pull_request
+
+  publish-prod:
+    image: plugins/gcr
+    repo: mirrormedia-1470651750304/${DRONE_REPO_NAME}
+    tag: stable-${DRONE_COMMIT_SHA:0:7}
+    environment:
+      - DOCKER_LAUNCH_DEBUG=true
+    secrets: [google_credentials]
+    dockerfile: docker/Dockerfile
+    build_args: STAGE_VERSION=${DRONE_COMMIT_SHA:0:7}
+    target: stable
+    when:
+      event: [tag]
       branch: [master]
 
   rebuild-cache:
@@ -64,6 +132,10 @@ pipeline:
       - node_modules
     volumes:
       - /tmp/cache:/cache
+    when:
+      event:
+        exclude:
+        - tag
 
   download-charts:
     image: gcr.io/mirrormedia-1470651750304/drone-cloud-sdk:latest
@@ -72,12 +144,20 @@ pipeline:
       - gcloud source repos clone helm ../helm
       - mkdir ./helm
       - cp -rf ../helm/mirror-voice ./helm/
+    when:
+      branch:
+        exclude:
+        - master
+      event:
+        include:
+        - push
+        - pull_request
 
-  helm_deploy_staging:
+  helm_deploy_review:
     image: quay.io/ipedrazas/drone-helm
     skip_tls_verify: true
     chart: ./helm/mirror-voice
-    release: "mirror-voice"
+    release: ${DRONE_REPO_NAME}-${DRONE_BRANCH}
     wait: true
     debug: true
     upgrade: true
@@ -86,25 +166,75 @@ pipeline:
     client_only: true
     service_account: tiller
     secrets: [api_server, kubernetes_token]
-    values: image.tag=${DRONE_COMMIT_SHA:0:7}
+    values: image.tag=${DRONE_COMMIT_SHA:0:7},fullnameOverride=${DRONE_REPO_NAME}-${DRONE_BRANCH},service.type=LoadBalancer
     # values_files: ["helm/staging.yml"]
-    namespace: default
+    namespace: review
     when:
-      event: push
-      branch: master
+      event:
+      - push
+      - pull_request
+      branch:
+        exclude:
+        - master
+
+  check-service-address:
+    image: gcr.io/mirrormedia-1470651750304/drone-gke-cli:latest
+    cluster: dev
+    zone: asia-east1-a
+    namespace: review
+    secrets: [google_credentials]
+    pull: true
+    when:
+      event:
+      - push
+      - pull_request
+      branch:
+        exclude:
+        - master
+
+  not-release-finish:
+    image: gcr.io/mirrormedia-1470651750304/drone-slack:latest
+    pull: true
+    channel: ground_control
+    secrets: [slack_webhook]
+    username: drone
+    link_names: true
+    icon_url: https://avatars2.githubusercontent.com/u/2181346?s=200&v=4
+    recipient: ${DRONE_COMMIT_AUTHOR}
+    usermaps:
+      chiangkeith: chiangkeith
+      FalseChord: Yen
+      hcchien: hcchien
+      hsuehyungtan: noah.tan
+      kwhsiung: kwhsiung
+      ichiaohsu: mmich
+    when:
+      event:
+      - push
+      - pull_request
+      branch:
+        exclude:
+        - master
+    template: >
+      {{#success build.status}}
+        {{repo.name}}:${DRONE_COMMIT_SHA:0:7} by {{build.author}} in branch {{build.branch}} was locked and loaded <{{build.serviceAddr}}|here>.
+      {{else}}
+        Houston, we have a problem. Build <${DRONE_BUILD_LINK}|#{{build.number}}> failed.
+      {{/success}}
 
   finish_notify:
     image: plugins/slack
-    channel: jenkins
+    channel: ground_control
     secrets: [slack_webhook]
     username: drone
     icon_url: https://avatars2.githubusercontent.com/u/2181346?s=200&v=4
     when:
       status: [success, failure]
       event: [push, pull_request, tag]
+      branch: master
     template: >
       {{#success build.status}}
-        ${DRONE_REPO_NAME}:${DRONE_COMMIT_SHA:0:7} was locked and loaded.
+        {{repo.name}}:${DRONE_COMMIT_SHA:0:7} by {{build.author}} in branch {{build.branch}} was locked and loaded.
       {{else}}
         Houston, we have a problem. Build <${DRONE_BUILD_LINK}|#{{build.number}}> failed.
       {{/success}}

--- a/.drone.yml
+++ b/.drone.yml
@@ -216,7 +216,7 @@ pipeline:
   configure:
     image: busybox:latest
     commands:
-      - cp ../configs/mirror-media/mirror-voice/stage/config.js ./server/config.js
+      - cp ../configs/mirror-media/mirror-voice/dev/config.js ./server/config.js
     when:
       event: push
       branch: [master, dev]

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,10 +4,10 @@ workspace:
 pipeline:
   # Send build start message to slack when pull_request and push
   # -------------------------------------- Test Sequence: Github Pull Request -------------------------------
-  start-notify:
-    image: gcr.io/mirrormedia-1470651750304/drone-slack:latest
+  pull-request-start:
+    image: gcr.io/mirrormedia-1470651750304/drone-slack:v1.0.0
     pull: true
-    channel: ground_control
+    channel: jenkins
     secrets: [slack_webhook]
     username: drone
     link_names: true
@@ -139,7 +139,7 @@ pipeline:
         - master
 
   check-service-address:
-    image: gcr.io/mirrormedia-1470651750304/drone-gke-cli:latest
+    image: gcr.io/mirrormedia-1470651750304/drone-gke-cli:v1.0.0
     cluster: dev
     zone: asia-east1-a
     namespace: review
@@ -152,9 +152,9 @@ pipeline:
         - master
 
   pull-request-finish:
-    image: gcr.io/mirrormedia-1470651750304/drone-slack:latest
+    image: gcr.io/mirrormedia-1470651750304/drone-slack:v1.0.0
     pull: true
-    channel: ground_control
+    channel: jenkins
     secrets: [slack_webhook]
     username: drone
     link_names: true
@@ -182,7 +182,7 @@ pipeline:
   # -------------------------------------- Release Candidate Sequence: Github Push --------------------------
   push-start:
     image: plugins/slack
-    channel: ground_control
+    channel: jenkins
     secrets: [slack_webhook]
     username: drone
     icon_url: https://avatars2.githubusercontent.com/u/2181346?s=200&v=4
@@ -288,7 +288,7 @@ pipeline:
 
   push-finish:
     image: plugins/slack
-    channel: ground_control
+    channel: jenkins
     secrets: [slack_webhook]
     username: drone
     icon_url: https://avatars2.githubusercontent.com/u/2181346?s=200&v=4
@@ -298,7 +298,7 @@ pipeline:
       branch: [master, dev]
     template: >
       {{#success build.status}}
-        {{repo.name}}:${DRONE_COMMIT_SHA:0:7} by {{build.author}} in branch {{build.branch}} was locked and loaded.
+        *{{repo.name}}:${DRONE_COMMIT_SHA:0:7}* by *{{build.author}}* in branch *{{build.branch}}* was locked and loaded.
       {{else}}
         Houston, we have a problem. Build <${DRONE_BUILD_LINK}|#{{build.number}}> failed.
       {{/success}}
@@ -306,15 +306,15 @@ pipeline:
   # ----------------------------------- Deployment Sequence: Git tag ------------------------------------
   release-start:
     image: plugins/slack
-    channel: ground_control
+    channel: jenkins
     secrets: [slack_webhook]
     username: drone
     icon_url: https://avatars2.githubusercontent.com/u/2181346?s=200&v=4
     template: >
-      Releasing mirror-voice:${DRONE_TAG}.
+      Releasing mirror-voice:${DRONE_TAG}
     when:
       event: [tag]
-      branch: [master, dev]
+      branch: master
 
   get-configs:
     image: gcr.io/mirrormedia-1470651750304/drone-cloud-sdk:latest
@@ -323,7 +323,7 @@ pipeline:
       - gcloud source repos clone configs ../configs
     when:
       event: tag
-      branch: [master, dev]
+      branch: master
 
   configure:
     image: busybox:latest
@@ -331,7 +331,7 @@ pipeline:
       - cp ../configs/mirror-media/mirror-voice/prod/config.js ./server/config.js
     when:
       event: [tag]
-      branch: [master, dev]
+      branch: master
 
   publish:
     image: plugins/gcr
@@ -347,45 +347,22 @@ pipeline:
     target: stable
     when:
       event: [tag]
-      branch: [master, dev]
-
-  copy-dist:
-    image: gcr.io/mirrormedia-1470651750304/${DRONE_REPO_NAME}:${DRONE_COMMIT_SHA:0:7}
-    commands:
-      - cp -rf /usr/src/dist .
-      - pwd
-      - ls
-    when:
-      event: tag
-      branch: [master, dev]
-
-  upload-dist:
-    image: plugins/gcs
-    source: dist
-    target: mirrormedia-files/dist/
-    acl: allUsers:READER
-    gzip: js, json
-    cache_control: public, max-age=2592000
-    token:
-      from_secret: google_credentials
-    when:
-      event: tag
-      branch: [master, dev]
+      branch: master
 
   release-finish:
     image: plugins/slack
-    channel: ground_control
+    channel: jenkins
     secrets: [slack_webhook]
     username: drone
     icon_url: https://avatars2.githubusercontent.com/u/2181346?s=200&v=4
     when:
       status: [success, failure]
       event: tag
-      branch: [master, dev]
+      branch: master
     template: >
       {{#success build.status}}
         *${DRONE_TAG}* was uploaded for *{{repo.name}}:${DRONE_COMMIT_SHA:0:7}*.
         Lets light this candle!.
       {{else}}
-        Houston, we have a problem. Build <${DRONE_BUILD_LINK}|#{{build.number}}> failed.
+        Houston, we have a problem. <${DRONE_BUILD_LINK}| Release ${DRONE_TAG}> failed.
       {{/success}}

--- a/.drone.yml
+++ b/.drone.yml
@@ -3,196 +3,8 @@ workspace:
   path: mirror-voice
 pipeline:
   # Send build start message to slack when pull_request and push
-  build_start:
-    image: plugins/slack
-    channel: ground_control
-    secrets: [slack_webhook]
-    username: drone
-    icon_url: https://avatars2.githubusercontent.com/u/2181346?s=200&v=4
-    template: >
-      Build <${DRONE_BUILD_LINK}|#{{build.number}}> *{{repo.name}}:${DRONE_COMMIT_SHA:0:7}* start.
-      {{build.author}} gave *{{build.branch}}* a little {{build.event}}.
-    when:
-      event:
-      - push
-      - pull_request
-
-  release_start:
-    image: plugins/slack
-    channel: ground_control
-    secrets: [slack_webhook]
-    username: drone
-    icon_url: https://avatars2.githubusercontent.com/u/2181346?s=200&v=4
-    template: >
-      Releasing mirror-voice:${DRONE_COMMIT_SHA:0.7}.
-    when:
-      event: [tag]
-      branch: [master]
-
-  # Only need to restore cache if building is necessary, which is pull_request and push
-  restore-cache:
-    image: drillster/drone-volume-cache
-    restore: true
-    mount:
-      - node_modules
-    volumes:
-      - /tmp/cache:/cache
-    when:
-      event:
-        include:
-        - pull_request
-        - push
-
-  get-configs:
-    image: gcr.io/mirrormedia-1470651750304/drone-cloud-sdk:latest
-    secrets: [google_credentials]
-    commands:
-      - gcloud source repos clone configs ../configs
-    when:
-      event:
-      - push
-      - pull_request
-      - tag
-
-  configure-dev:
-    image: busybox:latest
-    commands:
-      - cp ../configs/mirror-media/mirror-voice/${DRONE_BRANCH}/config.js ./server/config.js
-    when:
-      event:
-        exclude:
-        - tag
-      branch:
-        exclude:
-        - master
-
-  configure-stage:
-    image: busybox:latest
-    commands:
-      - cp ../configs/mirror-media/mirror-voice/stage/config.js ./server/config.js
-    when:
-      event:
-      - push
-      branch:
-      - master
-
-  configure-prod:
-    image: busybox:latest
-    commands:
-      - cp ../configs/mirror-media/mirror-voice/prod/config.js ./server/config.js
-    when:
-      event: [tag]
-      branch: [master]
-
-  # Build when pull_request are issued or commits pushed
-  build:
-    image: gcr.io/mirrormedia-1470651750304/mirror-voice:node-10.15.1-builder
-    commands:
-      - yarn install
-      - yarn run build
-      - yarn cache clean
-    when:
-      event: [push, pull_request]
-
-  publish:
-    image: plugins/gcr
-    repo: mirrormedia-1470651750304/${DRONE_REPO_NAME}
-    tag:
-    - ${DRONE_BRANCH}
-    - ${DRONE_COMMIT_SHA:0:7}
-    environment:
-      - DOCKER_LAUNCH_DEBUG=true
-    secrets: [google_credentials]
-    dockerfile: docker/Dockerfile
-    # build_args: STAGE_VERSION=${DRONE_COMMIT_BEFORE:0:7}
-    target: stage
-    when:
-      event:
-      - push
-      - pull_request
-
-  publish-prod:
-    image: plugins/gcr
-    repo: mirrormedia-1470651750304/${DRONE_REPO_NAME}
-    tag: stable-${DRONE_COMMIT_SHA:0:7}
-    environment:
-      - DOCKER_LAUNCH_DEBUG=true
-    secrets: [google_credentials]
-    dockerfile: docker/Dockerfile
-    build_args: STAGE_VERSION=${DRONE_COMMIT_SHA:0:7}
-    target: stable
-    when:
-      event: [tag]
-      branch: [master]
-
-  rebuild-cache:
-    image: drillster/drone-volume-cache
-    rebuild: true
-    mount:
-      - node_modules
-    volumes:
-      - /tmp/cache:/cache
-    when:
-      event:
-        exclude:
-        - tag
-
-  download-charts:
-    image: gcr.io/mirrormedia-1470651750304/drone-cloud-sdk:latest
-    secrets: [google_credentials]
-    commands:
-      - gcloud source repos clone helm ../helm
-      - mkdir ./helm
-      - cp -rf ../helm/mirror-voice ./helm/
-    when:
-      branch:
-        exclude:
-        - master
-      event:
-        include:
-        - push
-        - pull_request
-
-  helm_deploy_review:
-    image: quay.io/ipedrazas/drone-helm
-    skip_tls_verify: true
-    chart: ./helm/mirror-voice
-    release: ${DRONE_REPO_NAME}-${DRONE_BRANCH}
-    wait: true
-    debug: true
-    upgrade: true
-    reuse_values: true
-    recreate_pods: false
-    client_only: true
-    service_account: tiller
-    secrets: [api_server, kubernetes_token]
-    values: image.tag=${DRONE_COMMIT_SHA:0:7},fullnameOverride=${DRONE_REPO_NAME}-${DRONE_BRANCH},service.type=LoadBalancer
-    # values_files: ["helm/staging.yml"]
-    namespace: review
-    when:
-      event:
-      - push
-      - pull_request
-      branch:
-        exclude:
-        - master
-
-  check-service-address:
-    image: gcr.io/mirrormedia-1470651750304/drone-gke-cli:latest
-    cluster: dev
-    zone: asia-east1-a
-    namespace: review
-    secrets: [google_credentials]
-    pull: true
-    when:
-      event:
-      - push
-      - pull_request
-      branch:
-        exclude:
-        - master
-
-  not-release-finish:
+  # -------------------------------------- Test Sequence: Github Pull Request -------------------------------
+  start-notify:
     image: gcr.io/mirrormedia-1470651750304/drone-slack:latest
     pull: true
     channel: ground_control
@@ -209,20 +21,272 @@ pipeline:
       kwhsiung: kwhsiung
       ichiaohsu: mmich
     when:
-      event:
-      - push
-      - pull_request
+      event: pull_request
+      branch:
+        exclude:
+        - master
+    template: >
+      You issued a pull requsest:*${DRONE_COMMIT_SHA:0:7}* to {{repo.name}}:*{{build.branch}}*. Test build start.
+
+  restore-cache:
+    image: drillster/drone-volume-cache
+    restore: true
+    mount:
+      - node_modules
+    volumes:
+      - /tmp/cache:/cache
+    when:
+      event: pull_request
+      branch:
+        exclude:
+        - master
+
+  get-configs:
+    image: gcr.io/mirrormedia-1470651750304/drone-cloud-sdk:latest
+    secrets: [google_credentials]
+    commands:
+      - gcloud source repos clone configs ../configs
+    when:
+      event: pull_request
+      branch:
+        exclude:
+        - master
+
+  configure:
+    image: busybox:latest
+    commands:
+      - cp ../configs/mirror-media/mirror-voice/${DRONE_BRANCH}/config.js ./server/config.js
+    when:
+      event: pull_request
+      branch:
+        exclude:
+        - master
+
+  build:
+    image: gcr.io/mirrormedia-1470651750304/mirror-voice:node-10.15.1-builder
+    commands:
+      - yarn install
+      - yarn run build
+      - yarn cache clean
+    when:
+      event: pull_request
+      branch:
+        exclude:
+        - master
+
+  publish:
+    image: plugins/gcr
+    repo: mirrormedia-1470651750304/${DRONE_REPO_NAME}
+    tag:
+    - ${DRONE_BRANCH}
+    - ${DRONE_COMMIT_SHA:0:7}
+    environment:
+      - DOCKER_LAUNCH_DEBUG=true
+    secrets: [google_credentials]
+    dockerfile: docker/Dockerfile
+    # target: stage
+    when:
+      event: pull_request
+      branch:
+        exclude:
+        - master
+
+  rebuild-cache:
+    image: drillster/drone-volume-cache
+    rebuild: true
+    mount:
+      - node_modules
+    volumes:
+      - /tmp/cache:/cache
+    when:
+      event: pull_request
+      branch:
+        exclude:
+        - master
+
+  download-charts:
+    image: gcr.io/mirrormedia-1470651750304/drone-cloud-sdk:latest
+    secrets: [google_credentials]
+    commands:
+      - gcloud source repos clone helm ../helm
+      - mkdir ./helm
+      - cp -rf ../helm/mirror-voice ./helm/
+    when:
+      event: pull_request
+      branch:
+        exclude:
+        - master
+
+  helm-deploy-review:
+    image: quay.io/ipedrazas/drone-helm
+    skip_tls_verify: true
+    chart: ./helm/mirror-voice
+    release: ${DRONE_REPO_NAME}-${DRONE_BRANCH}
+    wait: true
+    # debug: true
+    upgrade: true
+    reuse_values: true
+    recreate_pods: false
+    client_only: true
+    service_account: tiller
+    secrets: [api_server, kubernetes_token]
+    values: image.tag=${DRONE_COMMIT_SHA:0:7},fullnameOverride=${DRONE_REPO_NAME}-${DRONE_BRANCH},service.type=LoadBalancer
+    namespace: review
+    when:
+      event: pull_request
+      branch:
+        exclude:
+        - master
+
+  check-service-address:
+    image: gcr.io/mirrormedia-1470651750304/drone-gke-cli:latest
+    cluster: dev
+    zone: asia-east1-a
+    namespace: review
+    secrets: [google_credentials]
+    pull: true
+    when:
+      event: pull_request
+      branch:
+        exclude:
+        - master
+
+  pull-request-finish:
+    image: gcr.io/mirrormedia-1470651750304/drone-slack:latest
+    pull: true
+    channel: ground_control
+    secrets: [slack_webhook]
+    username: drone
+    link_names: true
+    icon_url: https://avatars2.githubusercontent.com/u/2181346?s=200&v=4
+    recipient: ${DRONE_COMMIT_AUTHOR}
+    usermaps:
+      chiangkeith: chiangkeith
+      FalseChord: Yen
+      hcchien: hcchien
+      hsuehyungtan: noah.tan
+      kwhsiung: kwhsiung
+      ichiaohsu: mmich
+    when:
+      event: pull_request
       branch:
         exclude:
         - master
     template: >
       {{#success build.status}}
-        {{repo.name}}:${DRONE_COMMIT_SHA:0:7} by {{build.author}} in branch {{build.branch}} was locked and loaded <{{build.serviceAddr}}|here>.
+        Your server {{build.serviceAddr}} from commit *${DRONE_COMMIT_SHA:0:7}* in {{repo.name}}:{{build.branch}} was locked and loaded.
       {{else}}
-        Houston, we have a problem. Build <${DRONE_BUILD_LINK}|#{{build.number}}> failed.
+        Houston, we have a problem. Build <${DRONE_BUILD_LINK}|#{{build.number}}> failed. Fix me please.
       {{/success}}
 
-  finish_notify:
+  # -------------------------------------- Release Candidate Sequence: Github Push --------------------------
+  push-start:
+    image: plugins/slack
+    channel: ground_control
+    secrets: [slack_webhook]
+    username: drone
+    icon_url: https://avatars2.githubusercontent.com/u/2181346?s=200&v=4
+    template: >
+      {{build.author}} {{build.event}} ${DRONE_COMMIT_SHA:0:7} to *{{repo.name}}:{{build.branch}}*.
+      Build <${DRONE_BUILD_LINK}|#{{build.number}}> start.
+    when:
+      event: push
+      branch: [master, dev]
+
+  restore-cache:
+    image: drillster/drone-volume-cache
+    restore: true
+    mount:
+      - node_modules
+    volumes:
+      - /tmp/cache:/cache
+    when:
+      event: push
+      branch: [master, dev]
+
+  get-configs:
+    image: gcr.io/mirrormedia-1470651750304/drone-cloud-sdk:latest
+    secrets: [google_credentials]
+    commands:
+      - gcloud source repos clone configs ../configs
+    when:
+      event: push
+      branch: [master, dev]
+
+  configure:
+    image: busybox:latest
+    commands:
+      - cp ../configs/mirror-media/mirror-voice/stage/config.js ./server/config.js
+    when:
+      event: push
+      branch: [master, dev]
+
+  build:
+    image: gcr.io/mirrormedia-1470651750304/mirror-voice:node-10.15.1-builder
+    commands:
+      - yarn install
+      - yarn run build
+      - yarn cache clean
+    when:
+      event: push
+      branch: [master, dev]
+
+  publish:
+    image: plugins/gcr
+    repo: mirrormedia-1470651750304/${DRONE_REPO_NAME}
+    tag:
+    - ${DRONE_BRANCH}
+    - ${DRONE_COMMIT_SHA:0:7}
+    environment:
+      - DOCKER_LAUNCH_DEBUG=true
+    secrets: [google_credentials]
+    dockerfile: docker/Dockerfile
+    when:
+      event: push
+      branch: [master, dev]
+
+  rebuild-cache:
+    image: drillster/drone-volume-cache
+    rebuild: true
+    mount:
+      - node_modules
+    volumes:
+      - /tmp/cache:/cache
+    when:
+      event: push
+      branch: [master, dev]
+
+  download-charts:
+    image: gcr.io/mirrormedia-1470651750304/drone-cloud-sdk:latest
+    secrets: [google_credentials]
+    commands:
+      - gcloud source repos clone helm ../helm
+      - mkdir ./helm
+      - cp -rf ../helm/mirror-voice ./helm/
+    when:
+      event: push
+      branch: [master, dev]
+
+  helm-deploy-dev:
+    image: quay.io/ipedrazas/drone-helm
+    skip_tls_verify: true
+    chart: ./helm/mirror-voice
+    release: "mirror-voice"
+    wait: true
+    # debug: true
+    upgrade: true
+    reuse_values: true
+    recreate_pods: false
+    client_only: true
+    service_account: tiller
+    secrets: [api_server, kubernetes_token]
+    values: image.tag=${DRONE_COMMIT_SHA:0:7}
+    namespace: review
+    when:
+      event: push
+      branch: [master, dev]
+
+  push-finish:
     image: plugins/slack
     channel: ground_control
     secrets: [slack_webhook]
@@ -230,11 +294,98 @@ pipeline:
     icon_url: https://avatars2.githubusercontent.com/u/2181346?s=200&v=4
     when:
       status: [success, failure]
-      event: [push, pull_request, tag]
-      branch: master
+      event: push
+      branch: [master, dev]
     template: >
       {{#success build.status}}
         {{repo.name}}:${DRONE_COMMIT_SHA:0:7} by {{build.author}} in branch {{build.branch}} was locked and loaded.
+      {{else}}
+        Houston, we have a problem. Build <${DRONE_BUILD_LINK}|#{{build.number}}> failed.
+      {{/success}}
+
+  # ----------------------------------- Deployment Sequence: Git tag ------------------------------------
+  release-start:
+    image: plugins/slack
+    channel: ground_control
+    secrets: [slack_webhook]
+    username: drone
+    icon_url: https://avatars2.githubusercontent.com/u/2181346?s=200&v=4
+    template: >
+      Releasing mirror-voice:${DRONE_TAG}.
+    when:
+      event: [tag]
+      branch: [master, dev]
+
+  get-configs:
+    image: gcr.io/mirrormedia-1470651750304/drone-cloud-sdk:latest
+    secrets: [google_credentials]
+    commands:
+      - gcloud source repos clone configs ../configs
+    when:
+      event: tag
+      branch: [master, dev]
+
+  configure:
+    image: busybox:latest
+    commands:
+      - cp ../configs/mirror-media/mirror-voice/prod/config.js ./server/config.js
+    when:
+      event: [tag]
+      branch: [master, dev]
+
+  publish:
+    image: plugins/gcr
+    repo: mirrormedia-1470651750304/${DRONE_REPO_NAME}
+    tag:
+      - ${DRONE_TAG}
+      - stable
+    environment:
+      - DOCKER_LAUNCH_DEBUG=true
+    secrets: [google_credentials]
+    dockerfile: docker/Dockerfile.production
+    build_args: STAGE_VERSION=${DRONE_COMMIT_SHA:0:7}
+    target: stable
+    when:
+      event: [tag]
+      branch: [master, dev]
+
+  copy-dist:
+    image: gcr.io/mirrormedia-1470651750304/${DRONE_REPO_NAME}:${DRONE_COMMIT_SHA:0:7}
+    commands:
+      - cp -rf /usr/src/dist .
+      - pwd
+      - ls
+    when:
+      event: tag
+      branch: [master, dev]
+
+  upload-dist:
+    image: plugins/gcs
+    source: dist
+    target: mirrormedia-files/dist/
+    acl: allUsers:READER
+    gzip: js, json
+    cache_control: public, max-age=2592000
+    token:
+      from_secret: google_credentials
+    when:
+      event: tag
+      branch: [master, dev]
+
+  release-finish:
+    image: plugins/slack
+    channel: ground_control
+    secrets: [slack_webhook]
+    username: drone
+    icon_url: https://avatars2.githubusercontent.com/u/2181346?s=200&v=4
+    when:
+      status: [success, failure]
+      event: tag
+      branch: [master, dev]
+    template: >
+      {{#success build.status}}
+        *${DRONE_TAG}* was uploaded for *{{repo.name}}:${DRONE_COMMIT_SHA:0:7}*.
+        Lets light this candle!.
       {{else}}
         Houston, we have a problem. Build <${DRONE_BUILD_LINK}|#{{build.number}}> failed.
       {{/success}}

--- a/.gitignore
+++ b/.gitignore
@@ -83,4 +83,8 @@ dist
 # Service worker
 sw.*
 
+# Mac index
+.DS_Store
+
 server/config.js
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Docker for stage environment
-FROM node:10.15.1-alpine
+FROM node:10.15.1-alpine AS stage
 
 ENV NODE_SOURCE /usr/src
 WORKDIR $NODE_SOURCE
@@ -9,3 +9,5 @@ COPY . .
 EXPOSE 80
 
 CMD ["yarn", "start"]
+
+

--- a/docker/Dockerfile.production
+++ b/docker/Dockerfile.production
@@ -1,0 +1,9 @@
+ARG STAGE_VERSION=latest
+FROM gcr.io/mirrormedia-1470651750304/mirror-voice:${STAGE_VERSION}
+
+ENV NODE_SOURCE /usr/src
+# WORKDIR $NODE_SOURCE
+
+COPY ./server/config.js $NODE_SOURCE/server/config.js
+
+CMD ["npm", "start"]


### PR DESCRIPTION
In this pull request, I fulfilled the ideal developing cycle for mirror-voice:
There are three sections: `pull_request`, `push`, and `tag`

## Pull Request
When issued a pull request to any branch **except `master`**, a new version named with the branch name will be built and deployed to a review namespace. It will try to get the `config.js` under the name of this branch. It's nothing to do with `dev`. The result address will be sent to you only. **This procedure doesn't need to be merged. You could keep the pull request open and modify it multiple times until you are satisfied with it.

## Push to not master
Any push to **branch other than `master`** will be ignored. That is to say, nothing will happen when merged on branch that is not `master`

## Push to master
When pull requests are merged into `master` branch, drone will build the merged version, get  `/dev/config.js` from config repo for mirror-voice, and deploy it to `dev` cluster. The messages are going to be sent to **jenkins** channel.

## Tag master
When a commit on `master` branch is tagged, it will trigger the drone to use the corresponding docker for the commit built previously when pushed to master, get the config files `/prod/config.js` from the config repo, packed it into the docker then release to Google Container Registry.

For the sake of future releases, please name the tags with [Semantic Versioning 2.0.0](https://semver.org/). It has the structure like below:

${Major}.${Minor}.${Patch}-${Labels}

- MAJOR is for versions introducing massive, probably not back-compatible changes.
- MINOR is for versions that produce new feature, but have good compatibility.
- PATCH is for versions focusing on fixing minor bugs, or just patches.

For example, when current version is **v1.0.0**, 
- The next bug fix will have version v1.0.1
- The next new feature changes will have version v1.1.0
- The next breaking changes will have version v2.0.0

After this commit, the `master` will be protected against direct push.