### PR TITLE
Use valid build args for tag events

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -338,7 +338,7 @@ pipeline:
       - DOCKER_LAUNCH_DEBUG=true
     secrets: [google_credentials]
     dockerfile: docker/Dockerfile.production
-    build_args: STAGE_VERSION=${DRONE_BRANCH}-${DRONE_COMMIT_SHA:0:7}
+    build_args: STAGE_VERSION=master-${DRONE_COMMIT_SHA:0:7}
     target: stable
     when:
       event: tag


### PR DESCRIPTION
Drone cannot get tag branch, which is design in this way originally. Assigned explicitly to use `master-{COMMIT_SHA:0:7}` as the `build_args` to enable drone to find proper base image in publish.